### PR TITLE
Improve short name

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Fox\'s Magisk Module Manager</string>
-    <string name="app_name_short">Fox\'s Mmm</string>
+    <string name="app_name_short">Module Manager</string>
     <string name="fail_root_magisk">Failed to get access to Root or Magisk</string>
     <string name="loading">Loading…</string>
     <string name="updatable">Updatable</string>


### PR DESCRIPTION
"Fox's Mmm" seems hard to understand for the user, yet unique enough to be detected by apps that don't like root. 
How about just "module manager"? Or, if you want it even simpler, "modules".