### PR TITLE
Moving towards F-Droid inclusion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,11 @@ android {
         "default" {
             dimension "type"
             buildConfigField "boolean", "ENABLE_AUTO_UPDATER", "true"
+            buildConfigField(
+                "java.util.List<String>",
+                "DISABLED_REPOS",
+                "java.util.Arrays.asList()",
+            )
         }
 
         fdroid {
@@ -44,6 +49,14 @@ android {
             // forbids downloading blobs from third-party websites (and F-Droid APK isn't signed
             // with our keys, so the APK wouldn't install anyways).
             buildConfigField "boolean", "ENABLE_AUTO_UPDATER", "false"
+
+            // Repo with ads or tracking feature are disabled by default for the
+            // F-Droid flavor.
+            buildConfigField(
+                "java.util.List<String>",
+                "DISABLED_REPOS",
+                "java.util.Arrays.asList(\"androidacy_repo\")",
+            )
         }
     }
 

--- a/app/src/main/java/com/fox2code/mmm/repo/RepoData.java
+++ b/app/src/main/java/com/fox2code/mmm/repo/RepoData.java
@@ -2,6 +2,7 @@ package com.fox2code.mmm.repo;
 
 import android.content.SharedPreferences;
 
+import com.fox2code.mmm.BuildConfig;
 import com.fox2code.mmm.MainApplication;
 import com.fox2code.mmm.R;
 import com.fox2code.mmm.manager.ModuleInfo;
@@ -42,7 +43,7 @@ public class RepoData {
         this.moduleHashMap = new HashMap<>();
         this.name = this.url; // Set url as default name
         this.enabled = MainApplication.getSharedPreferences()
-                .getBoolean("pref_" + this.id + "_enabled", true);
+                .getBoolean("pref_" + this.id + "_enabled", this.isEnabledByDefault(this.id));
         if (!this.cacheRoot.isDirectory()) {
             this.cacheRoot.mkdirs();
         } else {
@@ -134,6 +135,10 @@ public class RepoData {
         return newModules;
     }
 
+    protected boolean isEnabledByDefault(String id) {
+        return !BuildConfig.DISABLED_REPOS.contains(id);
+    }
+
     public void storeMetadata(RepoModule repoModule,byte[] data) throws IOException {
         Files.write(new File(this.cacheRoot, repoModule.id + ".prop"), data);
     }
@@ -176,6 +181,6 @@ public class RepoData {
 
     public void updateEnabledState() {
         this.enabled = MainApplication.getSharedPreferences()
-                .getBoolean("pref_" + this.id + "_enabled", true);
+                .getBoolean("pref_" + this.id + "_enabled", this.isEnabledByDefault(this.id));
     }
 }

--- a/app/src/main/java/com/fox2code/mmm/settings/SettingsActivity.java
+++ b/app/src/main/java/com/fox2code/mmm/settings/SettingsActivity.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.fox2code.mmm.AppUpdateManager;
 import com.fox2code.mmm.BuildConfig;
@@ -203,6 +204,7 @@ public class SettingsActivity extends CompatActivity {
                     preference.setTitle(R.string.repo_disabled);
                     preference.setEnabled(false);
                 } else {
+                    ((TwoStatePreference)preference).setChecked(repoData.isEnabled());
                     preference.setTitle(repoData.isEnabled() ?
                             R.string.repo_enabled : R.string.repo_disabled);
                     preference.setOnPreferenceChangeListener((p, newValue) -> {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,4 +93,5 @@
     <string name="enable_blur_pref">Activer l\’effet de flou</string>
     <string name="repo_enabled">Dépôt activé</string>
     <string name="repo_disabled">Dépôt désactivé</string>
+    <string name="androidacy_repo_info">Le dépôt Androidacy utilise des publicités et des pisteurs.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,4 +93,5 @@
     <string name="enable_blur_pref">Enable blur</string>
     <string name="repo_enabled">Repo enabled</string>
     <string name="repo_disabled">Repo disabled</string>
+    <string name="androidacy_repo_info">Androidacy repo uses ads and trackers.</string>
 </resources>

--- a/app/src/main/res/xml/repo_preferences.xml
+++ b/app/src/main/res/xml/repo_preferences.xml
@@ -4,7 +4,6 @@
         app:key="pref_magisk_alt_repo"
         app:title="@string/loading">
         <SwitchPreferenceCompat
-            app:defaultValue="true"
             app:key="pref_magisk_alt_repo_enabled"
             app:icon="@drawable/ic_baseline_extension_24"
             app:switchTextOn="@string/repo_enabled"
@@ -25,7 +24,6 @@
         app:key="pref_androidacy_repo"
         app:title="@string/loading">
         <SwitchPreferenceCompat
-            app:defaultValue="true"
             app:key="pref_androidacy_repo_enabled"
             app:icon="@drawable/ic_baseline_extension_24"
             app:switchTextOn="@string/repo_enabled"

--- a/app/src/main/res/xml/repo_preferences.xml
+++ b/app/src/main/res/xml/repo_preferences.xml
@@ -48,6 +48,12 @@
             app:key="pref_androidacy_repo_submit"
             app:icon="@drawable/ic_baseline_upload_file_24"
             app:title="@string/submit_modules"
-            app:singleLineTitle="false"	/>
+            app:singleLineTitle="false" />
+        <Preference
+            app:key="pref_androidacy_ads_disclaimer"
+            app:icon="@drawable/ic_baseline_info_24"
+            app:enabled="false"
+            app:summary="@string/androidacy_repo_info"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
- Disable Androidacy repo by default in F-Droid build flavor. Note that it can still be enabled by manually opting in. (See https://gitlab.com/fdroid/fdroiddata/-/merge_requests/10830#note_898237184)
- Add disclaimer about Androidacy using ads and trackers. Note that this applies to all build flavors, but I think it's more transparent to users to show this disclamer regardless of the build flavor. (See https://gitlab.com/fdroid/fdroiddata/-/merge_requests/10830#note_898354128)

See also #41 .

<img src="https://user-images.githubusercontent.com/3407667/161379970-77e405ff-d177-432f-bf2f-4d960df42c08.png" alt="Screenshot_20220402-124808_Fox's_Magisk_Module_Manager" width=200>


