### PR TITLE
Build debug apks using workflow

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -36,13 +36,13 @@ jobs:
       # Upload Artifact Build
       # Noted For Output [module-name]/build/outputs/apk
       - name: Upload apk debug
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: FoxMmm-debug.apk
+          name: FoxMmm-debug
           path: app/build/outputs/apk/default/debug/app-default-debug.apk
 
-      - name: Upload apk debug-fdroid
-        uses: actions/upload-artifact@v2
+      - name: Upload apk fdroid-debug
+        uses: actions/upload-artifact@v3
         with:
-          name: FoxMmm-fdroid-debug.apk
-          path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
+          name: FoxMmm-fdroid-debug
+          path: app/build/outputs/apk/default/debug/app-default-debug.apk

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -1,0 +1,48 @@
+name: Generate APK Debug
+
+on:
+  # Triggers the workflow on push or pull request events but only for default and protected branches
+  push:
+    branches:
+      - master
+      - debug
+  pull_request:
+    branches: 
+      - master
+      - debug
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Change wrapper permissions
+        run: chmod +x ./gradlew
+
+      - name: Run tests
+        run: ./gradlew test
+
+      # Create APK Debug
+      - name: Build apk debug
+        run: ./gradlew assembleDebug
+
+      # Upload Artifact Build
+      # Noted For Output [module-name]/build/outputs/apk
+      - name: Upload apk debug
+        uses: actions/upload-artifact@v2
+        with:
+          name: FoxMmm-debug.apk
+          path: app/build/outputs/apk/default/debug/app-default-debug.apk
+
+      - name: Upload apk debug-fdroid
+        uses: actions/upload-artifact@v2
+        with:
+          name: FoxMmm-fdroid-debug.apk
+          path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk


### PR DESCRIPTION
Compiling apps works. They are not signed with certificate, so you have to uninstall the previous version before installing the new version.