### PR TITLE
Add empty sentry dsn to sentryless

### DIFF
--- a/app/src/sentryless/AndroidManifest.xml
+++ b/app/src/sentryless/AndroidManifest.xml
@@ -4,6 +4,7 @@
     tools:ignore="QueryAllPackagesPermission">
 
     <application android:icon="@mipmap/ic_launcher">
+        <meta-data android:name="io.sentry.dsn" android:value="" />
 
     </application>
 </manifest>


### PR DESCRIPTION
Fix https://github.com/Fox2Code/FoxMagiskModuleManager/issues/260

The dsn must be set else the app crashes.